### PR TITLE
Feature: display delay time

### DIFF
--- a/app/presenters/manager_statistics_presenter.rb
+++ b/app/presenters/manager_statistics_presenter.rb
@@ -27,4 +27,7 @@ class ManagerStatisticsPresenter < StatisticsPresenter
     end
   end
 
+  def delay
+    (elapsed_hours * @developers_count) - spent_hours
+  end
 end

--- a/app/presenters/statistics_presenter.rb
+++ b/app/presenters/statistics_presenter.rb
@@ -13,6 +13,10 @@ class StatisticsPresenter
     Date.today.iteration.total_hours
   end
 
+  def elapsed_hours
+    Date.today.iteration.elapsed_hours
+  end
+
   def hours
     @hours ||= "#{total_hours} (#{Date.today.iteration.business_hours})"
   end
@@ -25,5 +29,9 @@ class StatisticsPresenter
   def finished
     percentage = spent_hours / hours.to_f * 100
     "#{spent_hours} (#{percentage.round}%)"
+  end
+
+  def delay
+    elapsed_hours - spent_hours
   end
 end

--- a/app/views/layouts/_developer_statistics.html.slim
+++ b/app/views/layouts/_developer_statistics.html.slim
@@ -10,7 +10,10 @@ p
 
 p
   b=t('statistics.finished')
-
   span.pull-right=statistics.finished
+
+p
+  b = t('statistics.delay')
+  span.pull-right = statistics.delay
 
 canvas[iteration_stat_chart height='116' width='233' hours="#{statistics.total_hours}" finished="#{statistics.spent_hours}" id='iteration-stat-chart']

--- a/app/views/layouts/_manager_statistics.html.slim
+++ b/app/views/layouts/_manager_statistics.html.slim
@@ -10,7 +10,10 @@ p
 
 p
   b=t('statistics.finished')
-
   span.pull-right=statistics.finished
+
+p
+  b = t('statistics.delay')
+  span.pull-right = statistics.delay
 
 canvas[iteration_stat_chart height='116' width='233' hours="#{statistics.total_hours}" finished="#{statistics.spent_hours}" id='iteration-stat-chart']

--- a/config/locales/en/statistics.yml
+++ b/config/locales/en/statistics.yml
@@ -4,3 +4,4 @@ en:
     iteration: Iteration
     hours: Hours
     finished: Finished
+    delay: Delay

--- a/lib/ext/date.rb
+++ b/lib/ext/date.rb
@@ -42,6 +42,10 @@ class Iteration
   def total_hours
     dates.reject(&:weekend?).count * WORK_HOURS
   end
+
+  def elapsed_hours
+    dates.count { |d| d <= Date.today } * WORK_HOURS
+  end
 end
 
 class Date


### PR DESCRIPTION
For example today is 21.03.
Delay time = 6 (days in interval from 16-21) * 8 (work hours per day) - 13 (sum of real times) = 35.

![screenshot_2016-03-21_11-14-13](https://cloud.githubusercontent.com/assets/14460185/13913461/699b5730-ef60-11e5-903c-55cd19177b7f.png)
