### PR TITLE
Fix for links in wiki categories

### DIFF
--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -10,6 +10,6 @@ h1
       th = t('project_info.headers.actions')
     - @category.wiki_pages.each do |page|
       tr
-        td = link_to page.title, wiki_page_path( page )
+        td = link_to page.title, controller: 'wiki_pages', action: 'show', path: page.title
         td = page.updated_at.strftime("%d.%m.%y")
         td = actions_for(page, size: 'xs')


### PR DESCRIPTION
This PR fixes links to wiki articles on specific category page.
Path to article before:  `/categories/1?path=Title+example`.
After: `/wiki/Title%20example`.

Fix is not good enough, but works.